### PR TITLE
ability to use both element and selector

### DIFF
--- a/src/vue-data-scooper.js
+++ b/src/vue-data-scooper.js
@@ -63,7 +63,8 @@ const VueDataScooper = {
   install: function(Vue, options) {
     Vue.mixin({
       data: function() {
-        const root = document.querySelector(this.$options.el)
+        element = this.$options.el
+        const root = element instanceof Element ? element : document.querySelector(element)
         return getInitialData(root)
       }
     })


### PR DESCRIPTION
Hey Tsutomu Kuroda!

I'm unable to use 'element' variable as an el property (which is already founded node element):
```es6
var element = document.getElementById('new_account')
```

I think it will be a good idea to change the logic somewhere here:

```es6
const root = document.querySelector(this.$options.el)
```

To something like:
```es6
element = this.$options.el
const root = element instanceof Element ? element : document.querySelector(element)
```

What do you think?